### PR TITLE
Added new text

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,8 @@ and offers a *simple* and *intuitive* API.
 Check out the :doc:`usage` section for further information, including
 how to :ref:`installation` the project.
 
+Lumache has its documentation hosted on Read the Docs.
+
 .. note::
 
    This project is under active development.


### PR DESCRIPTION
added: Lumache has its documentation hosted on Read the Docs.